### PR TITLE
Update to 1.20

### DIFF
--- a/assets/minecraft/shaders/core/rendertype_entity_translucent_cull.fsh
+++ b/assets/minecraft/shaders/core/rendertype_entity_translucent_cull.fsh
@@ -9,8 +9,8 @@ uniform float FogStart;
 uniform float FogEnd;
 uniform vec4 FogColor;
 
-in int isGUI;
-in int isHand;
+flat in int isGUI;
+flat in int isHand;
 in float zpos;
 in float vertexDistance;
 in vec4 vertexColor;
@@ -33,12 +33,13 @@ void main() {
     if (color.a < 0.1) discard; // Snipped due to size.
 	
     // updated to 1.19.4 thanks to the der discohund
+    // updated to 1.20 thanks to HalbFettKaese + Evtema3
 
-    // Switch used parts of the texture depending on where the model is displayed
-    if (isGUI == 0 && roughly_equal(alpha, 253.0, 0.01)) discard;
+    // Switch used parts of the texture depending on where the model is displayed (using alpha255 by default)
+    if (isGUI == 0 && roughly_equal(alpha255, 253.0, 0.01)) discard;
     if (isGUI == 1) {
-             if (zpos  > 125.0 && roughly_equal(alpha, 254.0, 0.01)) discard;     // Handled as inventory slot
-        else if (zpos <= 125.0 && roughly_equal(alpha, 253.0, 0.01)) discard; // Handled as on the player doll
+             if (zpos  > 100.0 && roughly_equal(alpha255, 254.0, 0.01)) discard;     // Handled as inventory slot
+        else if (zpos <= 100.0 && roughly_equal(alpha255, 253.0, 0.01)) discard; // Handled as on the player doll
     }
 	
     fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);

--- a/assets/minecraft/shaders/core/rendertype_entity_translucent_cull.vsh
+++ b/assets/minecraft/shaders/core/rendertype_entity_translucent_cull.vsh
@@ -33,10 +33,11 @@ out vec2 texCoord2;
 out vec4 normal;
 
 // updated to 1.19.4 thanks to the der discohund
+// updated to 1.20 thanks to HalbFettKaese + Evtema3
 
 // gui item model detection from Onnowhere
 bool isgui(mat4 ProjMat) {
-    return ProjMat[3][2] == -2.0;
+    return abs(ProjMat[3][3]) > 0.01;
 }
 // first person hand item model detection from esben
 bool ishand(float FogStart) {

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
    "pack": {
-      "pack_format": 8,
+      "pack_format": 15,
       "description": "Adds a way to have different items in the hand and the GUI."
    }
 }


### PR DESCRIPTION
Referenced compatibility fixes from https://github.com/VisiVersa/Common-Shaders/ by @HalbFettKaese.

Resource pack now loads correctly by default by using `alpha255` in place of an undefined `alpha` variable in the fragment shader. Users may adjust this to `alpha100` on their own accord. Also patched OpenGL errors from taking in `isGUI` and `isHand` as non-flat ints.